### PR TITLE
Fix manifest package usage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="98" android:versionName="1.8.1" android:compileSdkVersion="34" android:compileSdkVersionCodename="14" package="pdf.pdfreader.viewer.editor.free" platformBuildVersionCode="34" platformBuildVersionName="14">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="98" android:versionName="1.8.1" android:compileSdkVersion="34" android:compileSdkVersionCodename="14" platformBuildVersionCode="34" platformBuildVersionName="14">
     <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="34"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
## Summary
- remove obsolete `package` attribute from `AndroidManifest.xml`

## Testing
- `./gradlew assembleDebug` *(fails: No route to host)*